### PR TITLE
fix: fixed g:fileheader_author option

### DIFF
--- a/doc/fileheader.txt
+++ b/doc/fileheader.txt
@@ -48,7 +48,7 @@ g:fileheader_auto_update                            *g:fileheader_auto_update*
 
                 Default value: 1
 
-g:fileheader_default_author                         *g:fileheader_default_author*
+g:fileheader_author                         *g:fileheader_author*
 
                 Set default author name.
 


### PR DESCRIPTION
我又来提 PR 了^_^。
照着 doc 配置了下，更新头信息时报错 `vim-fileheader: can not found g:fileheader_author value`，才发现文档里面写的是 `g:fileheader_author`，代码里面是 `g:fileheader_default_author`。