### PR TITLE
feat: add vue file comment suport

### DIFF
--- a/autoload/fileheader.vim
+++ b/autoload/fileheader.vim
@@ -36,6 +36,7 @@ let s:delimiter_map = {
   \ 'lua': s:haskell_style,
   \ 'html': s:html_style,
   \ 'xml': s:html_style,
+  \ 'vue': s:html_style,
   \ 'erlang': s:erlang_style,
   \ 'clojure': s:lisp_style,
   \ 'scheme': s:lisp_style,


### PR DESCRIPTION
<b>Hello, thank you very much for developing the File Header plug-in. Our company uses Vue for website development, and found that your plug-in does not support the Vue filetype, then I added this type to the autoload/fileheader.vim file.</b>